### PR TITLE
Add route_id to the data structure used by computeSchedules

### DIFF
--- a/compute-schedules.js
+++ b/compute-schedules.js
@@ -103,6 +103,7 @@ const computeSchedules = (readFile, filters = {}, computeSig = defComputeSig) =>
 		for (let tripId in trips) {
 			trips[tripId] = {
 				id: null, // to be used later
+          		route_id: trips[tripId].route_id,
 				trips: [tripId],
 				sequence: [], // stop_times[].stop_sequence mumbers
 				stops: [], // stop IDs

--- a/compute-schedules.js
+++ b/compute-schedules.js
@@ -63,7 +63,11 @@ const applyStopovers = (trips, readFile, filter) => {
 
 				// store the start time per trip
 				for (let i = 0; i < trip.trips.length; i++) {
-					trip.trips[i] = {tripId: trip.trips[i], start}
+					trip.trips[i] = {
+						tripId: trip.trips[i].tripId,
+						routeId: trip.trips[i].routeId,
+						start
+					}
 				}
 			}
 
@@ -103,7 +107,6 @@ const computeSchedules = (readFile, filters = {}, computeSig = defComputeSig) =>
 		for (let tripId in trips) {
 			trips[tripId] = {
 				id: null, // to be used later
-          		route_id: trips[tripId].route_id,
 				trips: [tripId],
 				sequence: [], // stop_times[].stop_sequence mumbers
 				stops: [], // stop IDs

--- a/readme.md
+++ b/readme.md
@@ -207,6 +207,7 @@ This utility computes what we called *schedules*, "patterns" by which vehicles v
 ```js
 {
 	id: '248tGP', // signature
+	route_id: "XXB-LYS" // useful for alternative signature function,
 	trips: [
 		// The trip `a downtown-all-day` follows this schedule and starts
 		// 55380 seconds after midnight on each day it runs.
@@ -215,6 +216,7 @@ This utility computes what we called *schedules*, "patterns" by which vehicles v
 	// Arrives at 0s at `airport`, departs 30s later.
 	// Arrives at 420s at `museum`, departs 60s later.
 	// Arrives at 720s at `center`, departs 90s later.
+	sequence: [1, 2, 3],
 	stops: ['airport', 'museum', 'center'],
 	arrivals: [0, 420, 720],
 	departures: [30, 480, 810]

--- a/readme.md
+++ b/readme.md
@@ -207,11 +207,10 @@ This utility computes what we called *schedules*, "patterns" by which vehicles v
 ```js
 {
 	id: '248tGP', // signature
-	route_id: "XXB-LYS" // useful for alternative signature function,
 	trips: [
 		// The trip `a downtown-all-day` follows this schedule and starts
 		// 55380 seconds after midnight on each day it runs.
-		{tripId: 'a-downtown-all-day', start: 55380}
+		{tripId: 'a-downtown-all-day', start: 55380, routeId: "XXB-LYS"}
 	],
 	// Arrives at 0s at `airport`, departs 30s later.
 	// Arrives at 420s at `museum`, departs 60s later.


### PR DESCRIPTION
Using this id as a signature (via custom computeSig) seems to work really well for me.

I'm not super familiar with gtfs so its possible that this approach is flawed in a way I'm missing.